### PR TITLE
use kclvm_primitives::IndexMap;

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,13 +1673,14 @@ dependencies = [
 
 [[package]]
 name = "kcl-lang"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "kclvm-api",
  "kclvm-evaluator",
  "kclvm-loader",
  "kclvm-parser",
+ "kclvm-primitives",
  "kclvm-runtime",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kcl-lang"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 readme = "README.md"
 documentation = "kcl-lang.io"
@@ -11,8 +11,9 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1"
-kclvm-api = { git = "https://github.com/kcl-lang/kcl", version = "0.11.1" }
-kclvm-evaluator = { git = "https://github.com/kcl-lang/kcl", version = "0.11.1" }
-kclvm-loader = { git = "https://github.com/kcl-lang/kcl", version = "0.11.1" }
-kclvm-parser = { git = "https://github.com/kcl-lang/kcl", version = "0.11.1" }
-kclvm-runtime = { git = "https://github.com/kcl-lang/kcl", version = "0.11.1" }
+kclvm-api = { git = "https://github.com/kcl-lang/kcl", version = "0.11.2" }
+kclvm-evaluator = { git = "https://github.com/kcl-lang/kcl", version = "0.11.2" }
+kclvm-loader = { git = "https://github.com/kcl-lang/kcl", version = "0.11.2" }
+kclvm-parser = { git = "https://github.com/kcl-lang/kcl", version = "0.11.2" }
+kclvm-runtime = { git = "https://github.com/kcl-lang/kcl", version = "0.11.2" }
+kclvm-primitives = { git = "https://github.com/kcl-lang/kcl", version = "0.11.2" }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,8 @@ use anyhow::{anyhow, Result};
 use kclvm_evaluator::Evaluator;
 use kclvm_loader::{load_packages, LoadPackageOptions};
 use kclvm_parser::LoadProgramOptions;
-use kclvm_runtime::{Context, IndexMap, PluginFunction, ValueRef};
+use kclvm_primitives::IndexMap;
+use kclvm_runtime::{Context, PluginFunction, ValueRef};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 fn my_plugin_sum(_: &Context, args: &ValueRef, _: &ValueRef) -> Result<ValueRef> {


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
• Import `IndexMap` from `kclvm_primitives` instead of `kclvm_runtime`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs</strong><dd><code>Refactor IndexMap import source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests.rs

• Changed import of <code>IndexMap</code> from <code>kclvm_runtime</code> to <code>kclvm_primitives</code><br> • <br>Separated the import into its own line for better organization


</details>


  </td>
  <td><a href="https://github.com/liangyuanpeng/kcl-lib/pull/2/files#diff-a0262fea108af44a98cc49e5eb72641963dd816513f2d0a22eb738fcfed55ebe">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR upgrades the project from version 0.11.1 to 0.11.2 while revising dependency management in Cargo files. It adds kclvm-primitives and ensures consistency across dependencies. The IndexMap import in src/tests.rs has been refactored to improve code clarity.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>